### PR TITLE
Searcher improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ This is Python training and testing code for Locally Optimized Product Quantizat
 
 ### Overview
 
-Locally Optimized Product Quantization (LOPQ) [1] is a hierarchical quantization algorithm that produces codes of configurable length for data points. These codes are efficient representations of the original vector and can be used in a variety of ways depending on application, including as hashes that preserve locality, as a compressed vector from which an approximate vector in the data space can be reconstructed, and as a representation from which to compute an approximation of the Euclidean distance between points.
+Locally Optimized Product Quantization (LOPQ) [1] is a hierarchical quantization algorithm that produces codes of configurable length for data points. These codes are efficient representations of the original vector and can be used in a variety of ways depending on the application, including as hashes that preserve locality, as a compressed vector from which an approximate vector in the data space can be reconstructed, and as a representation from which to compute an approximation of the Euclidean distance between points.
 
 Conceptually, the LOPQ quantization process can be broken into 4 phases. The training process also fits these phases to the data in the same order.
 
 1. The raw data vector is PCA'd to `D` dimensions (possibly the original dimensionality). This allows subsequent quantization to more efficiently represent the variation present in the data.
 2. The PCA'd data is then product quantized [2] by two k-means quantizers. This means that each vector is split into two subvectors each of dimension `D / 2`, and each of the two subspaces is quantized independently with a vocabulary of size `V`. Since the two quantizations occur independently, the dimensions of the vectors are permuted such that the total variance in each of the two subspaces is approximately equal, which allows the two vocabularies to be equally important in terms of capturing the total variance of the data. This results in a pair of cluster ids that we refer to as "coarse codes".
-3. The residuals of the data after coarse quantization are computed. The residuals are then locally projected independently for each coarse cluster. This projection is another application of PCA and dimension permutation on the residuals and it is "local" in the sense that there is a different projection for each cluster in each of the two coarse vocabularies. These local rotations make the next and final step, another application of product quantization, very efficient in capturing the variance of the residuals.
+3. The residuals of the data after coarse quantization are computed. The residuals are then locally projected independently for each coarse cluster. This projection is another application of PCA and dimension permutation on the residuals, and it is "local" in the sense that there is a different projection for each cluster in each of the two coarse vocabularies. These local rotations make the next and final step, another application of product quantization, very efficient in capturing the variance of the residuals.
 4. The locally projected data is then product quantized a final time by `M` subquantizers, resulting in `M` "fine codes". Usually the vocabulary for each of these subquantizers will be a power of 2 for effective storage in a search index. With vocabularies of size 256, the fine codes for each indexed vector will require `M` bytes to store in the index.
 
 The final LOPQ code for a vector is a `(coarse codes, fine codes)` pair, e.g. `((3, 2), (14, 164, 83, 49, 185, 29, 196, 250))`.
@@ -26,13 +26,13 @@ A nearest neighbor index can be built from these LOPQ codes by indexing each doc
 
 At query time, an incoming query vector undergoes substantially the same process. First, the query is split into coarse subvectors and the distance to each coarse centroid is computed. These distances can be used to efficiently compute a priority-ordered sequence of cells [3] such that cells later in the sequence are less likely to have near neighbors of the query than earlier cells. The items in cell buckets are retrieved in this order until some desired quota has been met.
 
-After this retrieval phase, the fine codes are used to rank by approximate Euclidean distance. The query is projected into each local space and the distance to each indexed item is estimated as the sum of the squared distances of the query subvectors to the corresponding subquantizer centroid indexed by the fine codes.
+After this retrieval phase, the fine codes are used to rank by approximate Euclidean distance. The query is projected into each local space and the distance to each indexed item is estimated as the sum of the squared distances of the query subvectors to the corresponding subquantizer centroids indexed by the fine codes.
 
 NN search with LOPQ is highly scalable and has excellent properties in terms of both index storage requirements and query-time latencies when implemented well.
 
 #### References
 
-For more information and performance benchmarks can be found at http://image.ntua.gr/iva/research/lopq/.
+More information and performance benchmarks can be found at http://image.ntua.gr/iva/research/lopq/.
 
 1. Y. Kalantidis, Y. Avrithis. [Locally Optimized Product Quantization for Approximate Nearest Neighbor Search.](http://image.ntua.gr/iva/files/lopq.pdf) CVPR 2014.
 2. H. Jegou, M. Douze, and C. Schmid. [Product quantization for nearest neighbor search.](https://lear.inrialpes.fr/pubs/2011/JDS11/jegou_searching_with_quantization.pdf) PAMI, 33(1), 2011.

--- a/python/lopq/search.py
+++ b/python/lopq/search.py
@@ -131,6 +131,24 @@ class LOPQSearcher(object):
 
         self.index = reduce(merge_dicts, index_dicts, self.index)
 
+    def add_codes(self, codes, ids=None):
+        """
+        Add LOPQ codes into the search index.
+
+        :param list codes:
+            a list of LOPQ code tuples
+        :param iterable ids:
+            an optional iterable of ids for each code;
+            defaults to the index of the code tuple if not provided
+        """
+        # If a list of ids is not provided, assume it is the index of the data
+        if ids is None:
+            ids = range(len(codes))
+
+        for item_id, code in zip(ids, codes):
+            cell = code[0]
+            self.index[cell].append((item_id, code))
+
     def get_result_quota(self, x, quota=10):
         """
         Given a query vector and result quota, retrieve as many cells as necessary

--- a/python/lopq/search.py
+++ b/python/lopq/search.py
@@ -202,7 +202,7 @@ class LOPQSearcher(object):
 
         return results
 
-    def search(self, x, quota=10, with_dists=False):
+    def search(self, x, quota=10, limit=None, with_dists=False):
         """
         Return euclidean distance ranked results, along with the number of cells
         traversed to fill the quota.
@@ -210,7 +210,9 @@ class LOPQSearcher(object):
         :param ndarray x:
             a query vector
         :param int quota:
-            the number of desired results
+            the number of desired results to rank
+        :param int limit:
+            the number of desired results to return - defaults to quota
         :param bool with_dists:
             boolean indicating whether result items should be returned with their distance
 
@@ -227,6 +229,11 @@ class LOPQSearcher(object):
 
         # Sort by distance
         results = sorted(results, key=lambda d: d[0])
+
+        # Limit number returned
+        if limit is None:
+            limit = quota
+        results = results[:limit]
 
         if with_dists:
             Result = namedtuple('Result', ['id', 'code', 'dist'])

--- a/python/lopq/search.py
+++ b/python/lopq/search.py
@@ -79,14 +79,7 @@ def multisequence(x, centroids):
                 heapq.heappush(h, (dist, c))
 
 
-class LOPQSearcher(object):
-    def __init__(self, model):
-        """
-        Create an LOPQSearcher instance that encapsulates retrieving and ranking
-        with LOPQ. Requires an LOPQModel instance.
-        """
-        self.model = model
-        self.index = defaultdict(list)
+class LOPQSearcherBase(object):
 
     def add_data(self, data, ids=None, num_procs=1):
         """
@@ -120,31 +113,6 @@ class LOPQSearcher(object):
 
         for item_id, code in zip(ids, codes):
             self.add_index_item(item_id, code)
-
-    def add_index_item(self, item_id, code):
-        """
-        Add an item to the index.
-
-        :param item_id:
-            a id for this item
-        :type item_id: any desired type to index
-        :param tuple code:
-            a LOPQ code tuple
-        """
-        cell = code[0]
-        self.index[cell].append((item_id, code))
-
-    def get_cell(self, cell):
-        """
-        Retrieve a cell bucket from the index.
-
-        :param tuple cell:
-            a cell tuple
-
-        :returns list:
-            the list of index items in this cell bucket
-        """
-        return self.index[cell]
 
     def get_result_quota(self, x, quota=10):
         """
@@ -255,3 +223,62 @@ class LOPQSearcher(object):
             results = map(lambda d: Result(d[1][0], d[1]), results)
 
         return results, visited
+
+    def add_index_item(self, item_id, code):
+        """
+        Add an item to the index.
+
+        :param item_id:
+            a id for this item
+        :type item_id: any desired type to index
+        :param tuple code:
+            a LOPQ code tuple
+        """
+        raise NotImplementedError()
+
+    def get_cell(self, cell):
+        """
+        Retrieve a cell bucket from the index.
+
+        :param tuple cell:
+            a cell tuple
+
+        :returns list:
+            the list of index items in this cell bucket
+        """
+        raise NotImplementedError()
+
+class LOPQSearcher(LOPQSearcherBase):
+    def __init__(self, model):
+        """
+        Create an LOPQSearcher instance that encapsulates retrieving and ranking
+        with LOPQ. Requires an LOPQModel instance.
+        """
+        self.model = model
+        self.index = defaultdict(list)
+
+    def add_index_item(self, item_id, code):
+        """
+        Add an item to the index.
+
+        :param item_id:
+            a id for this item
+        :type item_id: any desired type to index
+        :param tuple code:
+            a LOPQ code tuple
+        """
+        cell = code[0]
+        self.index[cell].append((item_id, code))
+
+    def get_cell(self, cell):
+        """
+        Retrieve a cell bucket from the index.
+
+        :param tuple cell:
+            a cell tuple
+
+        :returns list:
+            the list of index items in this cell bucket
+        """
+        return self.index[cell]
+

--- a/python/lopq/search.py
+++ b/python/lopq/search.py
@@ -97,23 +97,6 @@ class LOPQSearcherBase(object):
         codes = compute_codes_parallel(data, self.model, num_procs)
         self.add_codes(codes, ids)
 
-    def add_codes(self, codes, ids=None):
-        """
-        Add LOPQ codes into the search index.
-
-        :param iterable codes:
-            an iterable of LOPQ code tuples
-        :param iterable ids:
-            an optional iterable of ids for each code;
-            defaults to the index of the code tuple if not provided
-        """
-        # If a list of ids is not provided, assume it is the index of the data
-        if ids is None:
-            ids = count()
-
-        for item_id, code in zip(ids, codes):
-            self.add_index_item(item_id, code)
-
     def get_result_quota(self, x, quota=10):
         """
         Given a query vector and result quota, retrieve as many cells as necessary
@@ -224,15 +207,15 @@ class LOPQSearcherBase(object):
 
         return results, visited
 
-    def add_index_item(self, item_id, code):
+    def add_codes(self, codes, ids=None):
         """
-        Add an item to the index.
+        Add LOPQ codes into the search index.
 
-        :param item_id:
-            a id for this item
-        :type item_id: any desired type to index
-        :param tuple code:
-            a LOPQ code tuple
+        :param iterable codes:
+            an iterable of LOPQ code tuples
+        :param iterable ids:
+            an optional iterable of ids for each code;
+            defaults to the index of the code tuple if not provided
         """
         raise NotImplementedError()
 
@@ -252,23 +235,29 @@ class LOPQSearcher(LOPQSearcherBase):
     def __init__(self, model):
         """
         Create an LOPQSearcher instance that encapsulates retrieving and ranking
-        with LOPQ. Requires an LOPQModel instance.
+        with LOPQ. Requires an LOPQModel instance. This class uses a Python dict
+        to implement the index.
         """
         self.model = model
         self.index = defaultdict(list)
 
-    def add_index_item(self, item_id, code):
+    def add_codes(self, codes, ids=None):
         """
-        Add an item to the index.
+        Add LOPQ codes into the search index.
 
-        :param item_id:
-            a id for this item
-        :type item_id: any desired type to index
-        :param tuple code:
-            a LOPQ code tuple
+        :param iterable codes:
+            an iterable of LOPQ code tuples
+        :param iterable ids:
+            an optional iterable of ids for each code;
+            defaults to the index of the code tuple if not provided
         """
-        cell = code[0]
-        self.index[cell].append((item_id, code))
+        # If a list of ids is not provided, assume it is the index of the data
+        if ids is None:
+            ids = count()
+
+        for item_id, code in zip(ids, codes):
+            cell = code[0]
+            self.index[cell].append((item_id, code))
 
     def get_cell(self, cell):
         """
@@ -281,4 +270,3 @@ class LOPQSearcher(LOPQSearcherBase):
             the list of index items in this cell bucket
         """
         return self.index[cell]
-

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,6 @@
-nose==1.3.4
-numpy==1.10.1
-protobuf==2.6.1
-scikit-learn==0.17
-scipy==0.16.1
+nose>=1.3.4
+numpy>=1.10
+protobuf>=2.6
+scikit-learn>=0.15
+scipy>=0.15
+lmdb>=0.87

--- a/python/setup.py
+++ b/python/setup.py
@@ -83,7 +83,7 @@ setup_arguments = {
     },
     'platforms': 'Windows,Linux,Solaris,Mac OS-X,Unix',
     'include_package_data': True,
-    'install_requires': ['protobuf>=2.6', 'numpy>=1.10', 'scipy>=0.15', 'scikit-learn>=0.15']
+    'install_requires': ['protobuf>=2.6', 'numpy>=1.10', 'scipy>=0.15', 'scikit-learn>=0.15', 'lmdb>=0.87']
 }
 
 

--- a/python/test/tests.py
+++ b/python/test/tests.py
@@ -207,27 +207,38 @@ def test_searcher():
     data = pkl.load(open(relpath('./testdata/test_searcher_data.pkl')))
     m = LOPQModel.load_proto(relpath('./testdata/random_test_model.lopq'))
 
-    searcher = LOPQSearcher(m)
-    searcher.add_data(data)
+    # Helper to perform battery of tests
+    def test_searcher_instance(searcher, q):
+        retrieved, visited = searcher.get_result_quota(q)
+        assert_equal(len(retrieved), 12)
+        assert_equal(visited, 3)
+
+        retrieved, visited = searcher.search(q)
+        assert_equal(len(retrieved), 10)
+        assert_equal(visited, 3)
+
+        retrieved, visited = searcher.get_result_quota(q, quota=20)
+        assert_equal(len(retrieved), 28)
+        assert_equal(visited, 5)
+
+        retrieved, visited = searcher.search(q, quota=20)
+        assert_equal(len(retrieved), 20)
+        assert_equal(visited, 5)
+
+        retrieved, visited = searcher.search(q, quota=20, limit=10)
+        assert_equal(len(retrieved), 10)
+        assert_equal(visited, 5)
 
     q = np.ones(8)
 
-    retrieved, visited = searcher.get_result_quota(q)
-    assert_equal(len(retrieved), 12)
-    assert_equal(visited, 3)
+    # Test add_data
+    searcher = LOPQSearcher(m)
+    searcher.add_data(data)
+    test_searcher_instance(searcher, q)
 
-    retrieved, visited = searcher.search(q)
-    assert_equal(len(retrieved), 10)
-    assert_equal(visited, 3)
-
-    retrieved, visited = searcher.get_result_quota(q, quota=20)
-    assert_equal(len(retrieved), 28)
-    assert_equal(visited, 5)
-
-    retrieved, visited = searcher.search(q, quota=20)
-    assert_equal(len(retrieved), 20)
-    assert_equal(visited, 5)
-
-    retrieved, visited = searcher.search(q, quota=20, limit=10)
-    assert_equal(len(retrieved), 10)
-    assert_equal(visited, 5)
+    # Test add_codes
+    searcher = LOPQSearcher(m)
+    codes = [m.predict(x) for x in data]
+    searcher.add_codes(codes)
+    test_searcher_instance(searcher, q)
+    

--- a/python/test/tests.py
+++ b/python/test/tests.py
@@ -216,6 +216,18 @@ def test_searcher():
     assert_equal(len(retrieved), 12)
     assert_equal(visited, 3)
 
+    retrieved, visited = searcher.search(q)
+    assert_equal(len(retrieved), 10)
+    assert_equal(visited, 3)
+
     retrieved, visited = searcher.get_result_quota(q, quota=20)
     assert_equal(len(retrieved), 28)
+    assert_equal(visited, 5)
+
+    retrieved, visited = searcher.search(q, quota=20)
+    assert_equal(len(retrieved), 20)
+    assert_equal(visited, 5)
+
+    retrieved, visited = searcher.search(q, quota=20, limit=10)
+    assert_equal(len(retrieved), 10)
     assert_equal(visited, 5)

--- a/python/test/tests.py
+++ b/python/test/tests.py
@@ -10,7 +10,7 @@ from sklearn.cross_validation import train_test_split
 
 sys.path.insert(1, os.path.abspath('..'))
 from lopq.model import LOPQModel, eigenvalue_allocation, accumulate_covariance_estimators, compute_rotations_from_accumulators
-from lopq.search import LOPQSearcher
+from lopq.search import LOPQSearcher, LOPQSearcherLMDB
 from lopq.eval import compute_all_neighbors, get_cell_histogram, get_recall
 
 ########################################
@@ -203,42 +203,72 @@ def test_mat():
     os.remove(filename)
 
 
+def searcher_instance_battery(searcher, q):
+    """
+    Helper to perform battery of searcher tests.
+    """
+    retrieved, visited = searcher.get_result_quota(q)
+    assert_equal(len(retrieved), 12)
+    assert_equal(visited, 3)
+
+    retrieved, visited = searcher.search(q)
+    assert_equal(len(retrieved), 10)
+    assert_equal(visited, 3)
+
+    retrieved, visited = searcher.get_result_quota(q, quota=20)
+    assert_equal(len(retrieved), 28)
+    assert_equal(visited, 5)
+
+    retrieved, visited = searcher.search(q, quota=20)
+    assert_equal(len(retrieved), 20)
+    assert_equal(visited, 5)
+
+    retrieved, visited = searcher.search(q, quota=20, limit=10)
+    assert_equal(len(retrieved), 10)
+    assert_equal(visited, 5)
+
+
 def test_searcher():
     data = pkl.load(open(relpath('./testdata/test_searcher_data.pkl')))
     m = LOPQModel.load_proto(relpath('./testdata/random_test_model.lopq'))
-
-    # Helper to perform battery of tests
-    def test_searcher_instance(searcher, q):
-        retrieved, visited = searcher.get_result_quota(q)
-        assert_equal(len(retrieved), 12)
-        assert_equal(visited, 3)
-
-        retrieved, visited = searcher.search(q)
-        assert_equal(len(retrieved), 10)
-        assert_equal(visited, 3)
-
-        retrieved, visited = searcher.get_result_quota(q, quota=20)
-        assert_equal(len(retrieved), 28)
-        assert_equal(visited, 5)
-
-        retrieved, visited = searcher.search(q, quota=20)
-        assert_equal(len(retrieved), 20)
-        assert_equal(visited, 5)
-
-        retrieved, visited = searcher.search(q, quota=20, limit=10)
-        assert_equal(len(retrieved), 10)
-        assert_equal(visited, 5)
 
     q = np.ones(8)
 
     # Test add_data
     searcher = LOPQSearcher(m)
     searcher.add_data(data)
-    test_searcher_instance(searcher, q)
+    searcher_instance_battery(searcher, q)
 
     # Test add_codes
     searcher = LOPQSearcher(m)
     codes = [m.predict(x) for x in data]
     searcher.add_codes(codes)
-    test_searcher_instance(searcher, q)
-    
+    searcher_instance_battery(searcher, q)
+
+
+def test_searcher_lmdb():
+    import shutil
+
+    data = pkl.load(open(relpath('./testdata/test_searcher_data.pkl')))
+    m = LOPQModel.load_proto(relpath('./testdata/random_test_model.lopq'))
+
+    lmbd_test_path = './test_lopq_lmbd'
+    q = np.ones(8)
+
+    # Test add_data
+    searcher = LOPQSearcherLMDB(m, lmbd_test_path)
+    searcher.add_data(data)
+    searcher_instance_battery(searcher, q)
+
+    # Clean up
+    shutil.rmtree(lmbd_test_path)
+
+    # Test add_codes
+    searcher = LOPQSearcherLMDB(m, lmbd_test_path)
+    codes = [m.predict(x) for x in data]
+    searcher.add_codes(codes)
+    searcher_instance_battery(searcher, q)
+
+    # Clean up
+    shutil.rmtree(lmbd_test_path)
+


### PR DESCRIPTION
This PR makes improvements to the python searcher implementation

- It adds a `limit` kwarg to `LOPQSearcher#search` mostly to help highlight the fact that the number of desired results (limit) and the number to rank (quota) are distinct.
- Implements an `LOPQSearcher#add_codes` method.
- Factors parallel code computation out of searcher since it is general.
- Implements `LOPQSearcherLMDB` that is backed by `lmdb` rather than a python dict; add tests.

These changes should make working with bigger datasets easier.

@huyng @skamalas 