### PR TITLE
[MRG] Fix relative imports & improve package discovery

### DIFF
--- a/python/lopq/__init__.py
+++ b/python/lopq/__init__.py
@@ -1,8 +1,8 @@
 # Copyright 2015, Yahoo Inc.
 # Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
-import model
-import search
-import utils
+from . import model
+from . import search
+from . import utils
 from .model import LOPQModel
 from .search import LOPQSearcher, multisequence
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,7 @@
 # Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
 import os
 import json
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 # Package Metadata filename
@@ -60,7 +60,7 @@ setup_arguments = {
     'url': 'http://github.com/yahoo/lopq',
     'license': 'Apache-2.0',
     'keywords': ['lopq', 'locally optimized product quantization', 'product quantization', 'compression', 'ann', 'approximate nearest neighbor', 'similarity search'],
-    'packages': ['lopq'],
+    'packages': find_packages(),
     'long_description': LONG_DESCRIPTION,
     'description': 'Python code for training and deploying Locally Optimized Product Quantization (LOPQ) for approximate nearest neighbor search of high dimensional data.',
     'classifiers': [


### PR DESCRIPTION
Fixes #20. 

As described in [pep-0404](https://www.python.org/dev/peps/pep-0404/#imports):

> In Python 3, implicit relative imports within packages are no longer available - only absolute imports and explicit relative imports are supported.

The solution to the recent import problems, that is compatible with both python2 and python3 is to use explicit relative import. 

A more thorough discussion about this subject can be found [here](https://stackoverflow.com/questions/12172791/changes-in-import-statement-python3).

This PR:

- [x] Fixes the above import problem.
- [x] Improves package discovery. 
