### PR TITLE
[MRG] Solve some pep8/flake8 issues & some code refactoring

### DIFF
--- a/python/DESCRIPTION.md
+++ b/python/DESCRIPTION.md
@@ -1,0 +1,34 @@
+# Locally Optimized Product Quantization
+
+This is Python training and testing code for Locally Optimized Product Quantization (LOPQ) models, as well as Spark scripts to scale training to hundreds of millions of vectors. The resulting model can be used in Python with code provided here or deployed via a Protobuf format to, e.g., search backends for high performance approximate nearest neighbor search.
+
+### Overview
+
+Locally Optimized Product Quantization (LOPQ) [1] is a hierarchical quantization algorithm that produces codes of configurable length for data points. These codes are efficient representations of the original vector and can be used in a variety of ways depending on application, including as hashes that preserve locality, as a compressed vector from which an approximate vector in the data space can be reconstructed, and as a representation from which to compute an approximation of the Euclidean distance between points.
+
+Conceptually, the LOPQ quantization process can be broken into 4 phases. The training process also fits these phases to the data in the same order.
+
+1. The raw data vector is PCA'd to `D` dimensions (possibly the original dimensionality). This allows subsequent quantization to more efficiently represent the variation present in the data.
+2. The PCA'd data is then product quantized [2] by two k-means quantizers. This means that each vector is split into two subvectors each of dimension `D / 2`, and each of the two subspaces is quantized independently with a vocabulary of size `V`. Since the two quantizations occur independently, the dimensions of the vectors are permuted such that the total variance in each of the two subspaces is approximately equal, which allows the two vocabularies to be equally important in terms of capturing the total variance of the data. This results in a pair of cluster ids that we refer to as "coarse codes".
+3. The residuals of the data after coarse quantization are computed. The residuals are then locally projected independently for each coarse cluster. This projection is another application of PCA and dimension permutation on the residuals and it is "local" in the sense that there is a different projection for each cluster in each of the two coarse vocabularies. These local rotations make the next and final step, another application of product quantization, very efficient in capturing the variance of the residuals.
+4. The locally projected data is then product quantized a final time by `M` subquantizers, resulting in `M` "fine codes". Usually the vocabulary for each of these subquantizers will be a power of 2 for effective storage in a search index. With vocabularies of size 256, the fine codes for each indexed vector will require `M` bytes to store in the index.
+
+The final LOPQ code for a vector is a `(coarse codes, fine codes)` pair, e.g. `((3, 2), (14, 164, 83, 49, 185, 29, 196, 250))`.
+
+### Nearest Neighbor Search
+
+A nearest neighbor index can be built from these LOPQ codes by indexing each document into its corresponding coarse code bucket. That is, each pair of coarse codes (which we refer to as a "cell") will index a bucket of the vectors quantizing to that cell.
+
+At query time, an incoming query vector undergoes substantially the same process. First, the query is split into coarse subvectors and the distance to each coarse centroid is computed. These distances can be used to efficiently compute a priority-ordered sequence of cells [3] such that cells later in the sequence are less likely to have near neighbors of the query than earlier cells. The items in cell buckets are retrieved in this order until some desired quota has been met.
+
+After this retrieval phase, the fine codes are used to rank by approximate Euclidean distance. The query is projected into each local space and the distance to each indexed item is estimated as the sum of the squared distances of the query subvectors to the corresponding subquantizer centroid indexed by the fine codes.
+
+NN search with LOPQ is highly scalable and has excellent properties in terms of both index storage requirements and query-time latencies when implemented well.
+
+#### References
+
+For more information and performance benchmarks can be found at http://image.ntua.gr/iva/research/lopq/.
+
+1. Y. Kalantidis, Y. Avrithis. [Locally Optimized Product Quantization for Approximate Nearest Neighbor Search.](http://image.ntua.gr/iva/files/lopq.pdf) CVPR 2014.
+2. H. Jegou, M. Douze, and C. Schmid. [Product quantization for nearest neighbor search.](https://lear.inrialpes.fr/pubs/2011/JDS11/jegou_searching_with_quantization.pdf) PAMI, 33(1), 2011.
+3. A. Babenko and V. Lempitsky. [The inverted multi-index.](http://www.computer.org/csdl/trans/tp/preprint/06915715.pdf) CVPR 2012.

--- a/python/lopq/__init__.py
+++ b/python/lopq/__init__.py
@@ -1,5 +1,6 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 import model
 import search
 import utils

--- a/python/lopq/eval.py
+++ b/python/lopq/eval.py
@@ -1,13 +1,13 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 import time
 import numpy as np
 
 
 def compute_all_neighbors(data1, data2=None, just_nn=True):
-    """
-    For each point in data1, compute a ranked list of neighbor indices from data2.
-    If data2 is not provided, compute neighbors relative to data1
+    """ For each point in data1, compute a ranked list of neighbor indices
+    from data2. If data2 is not provided, compute neighbors relative to data1
 
     :param ndarray data1:
         an m1 x n dim matrix with observations on the rows
@@ -15,7 +15,8 @@ def compute_all_neighbors(data1, data2=None, just_nn=True):
         an m2 x n dim matrix with observations on the rows
 
     :returns ndarray:
-        an m1 x m2 dim matrix with the distance-sorted indices of neighbors on the rows
+        an m1 x m2 dim matrix with the distance-sorted indices of neighbors
+        on the rows
     """
     from scipy.spatial.distance import cdist
 
@@ -89,10 +90,11 @@ def get_proportion_of_reconstructions_with_same_codes(data, model):
     return float(count) / N
 
 
-def get_recall(searcher, queries, nns, thresholds=[1, 10, 100, 1000], normalize=True, verbose=False):
-    """
-    Given a LOPQSearcher object with indexed data and groundtruth nearest neighbors for a set of test
-    query vectors, collect and return recall statistics.
+def get_recall(searcher, queries, nns, thresholds=[1, 10, 100, 1000],
+               normalize=True, verbose=False):
+    """ Given a LOPQSearcher object with indexed data and groundtruth nearest
+    neighbors for a set of test query vectors, collect and return recall
+    statistics.
 
     :param LOPQSearcher searcher:
         a searcher that contains the indexed nearest neighbors
@@ -101,10 +103,11 @@ def get_recall(searcher, queries, nns, thresholds=[1, 10, 100, 1000], normalize=
     :param ndarray nns:
         a list of true nearest neighbor ids for each vector in queries
     :param list thresholds:
-        the recall thresholds to evaluate - the last entry defines the number of
-        results to retrieve before ranking
+        the recall thresholds to evaluate - the last entry defines the number
+        of results to retrieve before ranking
     :param bool normalize:
-        flag to indicate whether the result should be normalized by the number of queries
+        flag to indicate whether the result should be normalized by the number
+        of queries
     :param bool verbose:
         flag to print every 50th search to visualize progress
 
@@ -156,7 +159,9 @@ def get_subquantizer_distortion(data, model):
     pall = np.concatenate((p1, p2), axis=1)
     suball = model.subquantizers[0] + model.subquantizers[1]
 
-    dists = np.array([sum(np.linalg.norm(compute_residuals(d, c)[
-                     0], ord=2, axis=1) ** 2) for c, d in zip(suball, np.split(pall, 8, axis=1))])
+    dists = np.array([
+        sum(np.linalg.norm(compute_residuals(d, c)[0], ord=2, axis=1) ** 2)
+        for c, d in zip(suball, np.split(pall, 8, axis=1))
+        ])
 
     return dists / data.shape[0]

--- a/python/lopq/eval.py
+++ b/python/lopq/eval.py
@@ -156,6 +156,7 @@ def get_subquantizer_distortion(data, model):
     pall = np.concatenate((p1, p2), axis=1)
     suball = model.subquantizers[0] + model.subquantizers[1]
 
-    dists = np.array([sum(np.linalg.norm(compute_residuals(d, c)[0], ord=2, axis=1) ** 2) for c, d in zip(suball, np.split(pall, 8, axis=1))])
+    dists = np.array([sum(np.linalg.norm(compute_residuals(d, c)[
+                     0], ord=2, axis=1) ** 2) for c, d in zip(suball, np.split(pall, 8, axis=1))])
 
     return dists / data.shape[0]

--- a/python/lopq/lopq_model_pb2.py
+++ b/python/lopq/lopq_model_pb2.py
@@ -2,10 +2,8 @@
 # source: lopq_model.proto
 
 import sys
-_b = (sys.version_info[0] < 3 and
-      (lambda x: x) or
-      (lambda x: x.encode('latin1'))
-      )
+_b = (sys.version_info[0] < 3 and (lambda x: x) or (
+      lambda x: x.encode('latin1')))
 
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
@@ -40,7 +38,7 @@ _VECTOR = _descriptor.Descriptor(
             is_extension=False, extension_scope=None,
             options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(),
                                               _b('\020\001'))
-            ),],
+        ), ],
     extensions=[],
     nested_types=[],
     enum_types=[],

--- a/python/lopq/lopq_model_pb2.py
+++ b/python/lopq/lopq_model_pb2.py
@@ -2,7 +2,11 @@
 # source: lopq_model.proto
 
 import sys
-_b=sys.version_info[0]<3 and (lambda x:x) or (lambda x:x.encode('latin1'))
+_b = (sys.version_info[0] < 3 and
+      (lambda x: x) or
+      (lambda x: x.encode('latin1'))
+      )
+
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
@@ -13,161 +17,149 @@ from google.protobuf import descriptor_pb2
 _sym_db = _symbol_database.Default()
 
 
-
-
 DESCRIPTOR = _descriptor.FileDescriptor(
-  name='lopq_model.proto',
-  package='com.flickr.vision.lopq',
-  serialized_pb=_b('\n\x10lopq_model.proto\x12\x16\x63om.flickr.vision.lopq\"\x1c\n\x06Vector\x12\x12\n\x06values\x18\x01 \x03(\x02\x42\x02\x10\x01\"+\n\x06Matrix\x12\x12\n\x06values\x18\x01 \x03(\x02\x42\x02\x10\x01\x12\r\n\x05shape\x18\x02 \x03(\r\"\x80\x02\n\x0fLOPQModelParams\x12\t\n\x01\x44\x18\x01 \x01(\r\x12\t\n\x01V\x18\x02 \x01(\r\x12\t\n\x01M\x18\x03 \x01(\r\x12\x19\n\x11num_subquantizers\x18\x04 \x01(\r\x12*\n\x02\x43s\x18\x05 \x03(\x0b\x32\x1e.com.flickr.vision.lopq.Matrix\x12*\n\x02Rs\x18\x06 \x03(\x0b\x32\x1e.com.flickr.vision.lopq.Matrix\x12+\n\x03mus\x18\x07 \x03(\x0b\x32\x1e.com.flickr.vision.lopq.Vector\x12,\n\x04subs\x18\x08 \x03(\x0b\x32\x1e.com.flickr.vision.lopq.MatrixB/\n\x16\x63om.flickr.vision.lopqB\x13LOPQModelParametersH\x01')
+    name='lopq_model.proto',
+    package='com.flickr.vision.lopq',
+    serialized_pb=_b('\n\x10lopq_model.proto\x12\x16\x63om.flickr.vision.lopq\"\x1c\n\x06Vector\x12\x12\n\x06values\x18\x01 \x03(\x02\x42\x02\x10\x01\"+\n\x06Matrix\x12\x12\n\x06values\x18\x01 \x03(\x02\x42\x02\x10\x01\x12\r\n\x05shape\x18\x02 \x03(\r\"\x80\x02\n\x0fLOPQModelParams\x12\t\n\x01\x44\x18\x01 \x01(\r\x12\t\n\x01V\x18\x02 \x01(\r\x12\t\n\x01M\x18\x03 \x01(\r\x12\x19\n\x11num_subquantizers\x18\x04 \x01(\r\x12*\n\x02\x43s\x18\x05 \x03(\x0b\x32\x1e.com.flickr.vision.lopq.Matrix\x12*\n\x02Rs\x18\x06 \x03(\x0b\x32\x1e.com.flickr.vision.lopq.Matrix\x12+\n\x03mus\x18\x07 \x03(\x0b\x32\x1e.com.flickr.vision.lopq.Vector\x12,\n\x04subs\x18\x08 \x03(\x0b\x32\x1e.com.flickr.vision.lopq.MatrixB/\n\x16\x63om.flickr.vision.lopqB\x13LOPQModelParametersH\x01')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 
-
-
 _VECTOR = _descriptor.Descriptor(
-  name='Vector',
-  full_name='com.flickr.vision.lopq.Vector',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='values', full_name='com.flickr.vision.lopq.Vector.values', index=0,
-      number=1, type=2, cpp_type=6, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\020\001'))),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=44,
-  serialized_end=72,
+    name='Vector',
+    full_name='com.flickr.vision.lopq.Vector',
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name='values', full_name='com.flickr.vision.lopq.Vector.values',
+            index=0, number=1, type=2, cpp_type=6, label=3,
+            has_default_value=False, default_value=[],
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(),
+                                              _b('\020\001'))
+            ),],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    options=None,
+    is_extendable=False,
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=44,
+    serialized_end=72,
 )
 
 
 _MATRIX = _descriptor.Descriptor(
-  name='Matrix',
-  full_name='com.flickr.vision.lopq.Matrix',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='values', full_name='com.flickr.vision.lopq.Matrix.values', index=0,
-      number=1, type=2, cpp_type=6, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\020\001'))),
-    _descriptor.FieldDescriptor(
-      name='shape', full_name='com.flickr.vision.lopq.Matrix.shape', index=1,
-      number=2, type=13, cpp_type=3, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=74,
-  serialized_end=117,
+    name='Matrix',
+    full_name='com.flickr.vision.lopq.Matrix',
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name='values', full_name='com.flickr.vision.lopq.Matrix.values', index=0,
+            number=1, type=2, cpp_type=6, label=3,
+            has_default_value=False, default_value=[],
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=_descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\020\001'))),
+        _descriptor.FieldDescriptor(
+            name='shape', full_name='com.flickr.vision.lopq.Matrix.shape', index=1,
+            number=2, type=13, cpp_type=3, label=3,
+            has_default_value=False, default_value=[],
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    options=None,
+    is_extendable=False,
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=74,
+    serialized_end=117,
 )
 
 
 _LOPQMODELPARAMS = _descriptor.Descriptor(
-  name='LOPQModelParams',
-  full_name='com.flickr.vision.lopq.LOPQModelParams',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='D', full_name='com.flickr.vision.lopq.LOPQModelParams.D', index=0,
-      number=1, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='V', full_name='com.flickr.vision.lopq.LOPQModelParams.V', index=1,
-      number=2, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='M', full_name='com.flickr.vision.lopq.LOPQModelParams.M', index=2,
-      number=3, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='num_subquantizers', full_name='com.flickr.vision.lopq.LOPQModelParams.num_subquantizers', index=3,
-      number=4, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Cs', full_name='com.flickr.vision.lopq.LOPQModelParams.Cs', index=4,
-      number=5, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='Rs', full_name='com.flickr.vision.lopq.LOPQModelParams.Rs', index=5,
-      number=6, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='mus', full_name='com.flickr.vision.lopq.LOPQModelParams.mus', index=6,
-      number=7, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='subs', full_name='com.flickr.vision.lopq.LOPQModelParams.subs', index=7,
-      number=8, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  options=None,
-  is_extendable=False,
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=120,
-  serialized_end=376,
+    name='LOPQModelParams',
+    full_name='com.flickr.vision.lopq.LOPQModelParams',
+    filename=None,
+    file=DESCRIPTOR,
+    containing_type=None,
+    fields=[
+        _descriptor.FieldDescriptor(
+            name='D', full_name='com.flickr.vision.lopq.LOPQModelParams.D', index=0,
+            number=1, type=13, cpp_type=3, label=1,
+            has_default_value=False, default_value=0,
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+        _descriptor.FieldDescriptor(
+            name='V', full_name='com.flickr.vision.lopq.LOPQModelParams.V', index=1,
+            number=2, type=13, cpp_type=3, label=1,
+            has_default_value=False, default_value=0,
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+        _descriptor.FieldDescriptor(
+            name='M', full_name='com.flickr.vision.lopq.LOPQModelParams.M', index=2,
+            number=3, type=13, cpp_type=3, label=1,
+            has_default_value=False, default_value=0,
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+        _descriptor.FieldDescriptor(
+            name='num_subquantizers', full_name='com.flickr.vision.lopq.LOPQModelParams.num_subquantizers', index=3,
+            number=4, type=13, cpp_type=3, label=1,
+            has_default_value=False, default_value=0,
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+        _descriptor.FieldDescriptor(
+            name='Cs', full_name='com.flickr.vision.lopq.LOPQModelParams.Cs', index=4,
+            number=5, type=11, cpp_type=10, label=3,
+            has_default_value=False, default_value=[],
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+        _descriptor.FieldDescriptor(
+            name='Rs', full_name='com.flickr.vision.lopq.LOPQModelParams.Rs', index=5,
+            number=6, type=11, cpp_type=10, label=3,
+            has_default_value=False, default_value=[],
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+        _descriptor.FieldDescriptor(
+            name='mus', full_name='com.flickr.vision.lopq.LOPQModelParams.mus', index=6,
+            number=7, type=11, cpp_type=10, label=3,
+            has_default_value=False, default_value=[],
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+        _descriptor.FieldDescriptor(
+            name='subs', full_name='com.flickr.vision.lopq.LOPQModelParams.subs', index=7,
+            number=8, type=11, cpp_type=10, label=3,
+            has_default_value=False, default_value=[],
+            message_type=None, enum_type=None, containing_type=None,
+            is_extension=False, extension_scope=None,
+            options=None),
+    ],
+    extensions=[],
+    nested_types=[],
+    enum_types=[],
+    options=None,
+    is_extendable=False,
+    extension_ranges=[],
+    oneofs=[],
+    serialized_start=120,
+    serialized_end=376,
 )
 
 _LOPQMODELPARAMS.fields_by_name['Cs'].message_type = _MATRIX
@@ -179,31 +171,34 @@ DESCRIPTOR.message_types_by_name['Matrix'] = _MATRIX
 DESCRIPTOR.message_types_by_name['LOPQModelParams'] = _LOPQMODELPARAMS
 
 Vector = _reflection.GeneratedProtocolMessageType('Vector', (_message.Message,), dict(
-  DESCRIPTOR = _VECTOR,
-  __module__ = 'lopq_model_pb2'
-  # @@protoc_insertion_point(class_scope:com.flickr.vision.lopq.Vector)
-  ))
+    DESCRIPTOR=_VECTOR,
+    __module__='lopq_model_pb2'
+    # @@protoc_insertion_point(class_scope:com.flickr.vision.lopq.Vector)
+))
 _sym_db.RegisterMessage(Vector)
 
 Matrix = _reflection.GeneratedProtocolMessageType('Matrix', (_message.Message,), dict(
-  DESCRIPTOR = _MATRIX,
-  __module__ = 'lopq_model_pb2'
-  # @@protoc_insertion_point(class_scope:com.flickr.vision.lopq.Matrix)
-  ))
+    DESCRIPTOR=_MATRIX,
+    __module__='lopq_model_pb2'
+    # @@protoc_insertion_point(class_scope:com.flickr.vision.lopq.Matrix)
+))
 _sym_db.RegisterMessage(Matrix)
 
 LOPQModelParams = _reflection.GeneratedProtocolMessageType('LOPQModelParams', (_message.Message,), dict(
-  DESCRIPTOR = _LOPQMODELPARAMS,
-  __module__ = 'lopq_model_pb2'
-  # @@protoc_insertion_point(class_scope:com.flickr.vision.lopq.LOPQModelParams)
-  ))
+    DESCRIPTOR=_LOPQMODELPARAMS,
+    __module__='lopq_model_pb2'
+    # @@protoc_insertion_point(class_scope:com.flickr.vision.lopq.LOPQModelParams)
+))
 _sym_db.RegisterMessage(LOPQModelParams)
 
 
 DESCRIPTOR.has_options = True
-DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b('\n\026com.flickr.vision.lopqB\023LOPQModelParametersH\001'))
+DESCRIPTOR._options = _descriptor._ParseOptions(descriptor_pb2.FileOptions(), _b(
+    '\n\026com.flickr.vision.lopqB\023LOPQModelParametersH\001'))
 _VECTOR.fields_by_name['values'].has_options = True
-_VECTOR.fields_by_name['values']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\020\001'))
+_VECTOR.fields_by_name['values']._options = _descriptor._ParseOptions(
+    descriptor_pb2.FieldOptions(), _b('\020\001'))
 _MATRIX.fields_by_name['values'].has_options = True
-_MATRIX.fields_by_name['values']._options = _descriptor._ParseOptions(descriptor_pb2.FieldOptions(), _b('\020\001'))
+_MATRIX.fields_by_name['values']._options = _descriptor._ParseOptions(
+    descriptor_pb2.FieldOptions(), _b('\020\001'))
 # @@protoc_insertion_point(module_scope)

--- a/python/lopq/model.py
+++ b/python/lopq/model.py
@@ -748,16 +748,16 @@ class LOPQModel(object):
             m.values.extend(map(float, np.nditer(a, order='C')))
             return m
 
-        if self.Cs != None:
+        if self.Cs is not None:
             for C in self.Cs:
                 matrix_from_ndarray(lopq_params.Cs.add(), C)
-        if self.Rs != None:
+        if self.Rs is not None:
             for R in chain(*self.Rs):
                 matrix_from_ndarray(lopq_params.Rs.add(), R)
-        if self.mus != None:
+        if self.mus is not None:
             for mu in chain(*self.mus):
                 vector_from_ndarray(lopq_params.mus.add(), mu)
-        if self.subquantizers != None:
+        if self.subquantizers is not None:
             for sub in chain(*self.subquantizers):
                 matrix_from_ndarray(lopq_params.subs.add(), sub)
 

--- a/python/lopq/search.py
+++ b/python/lopq/search.py
@@ -301,8 +301,11 @@ class LOPQSearcherLMDB(LOPQSearcherBase):
         self.lmdb_path = lmdb_path
         self.id_lambda = id_lambda
 
-        self.env = lmdb.open(self.lmdb_path, map_size=1024 *
-                             2000000*2, writemap=False, map_async=True, max_dbs=1)
+        self.env = lmdb.open(self.lmdb_path,
+                             map_size=1024 * 2000000 * 2,
+                             writemap=False,
+                             map_async=True,
+                             max_dbs=1)
         self.index_db = self.env.open_db("index")
 
     def encode_cell(self, cell):

--- a/python/lopq/search.py
+++ b/python/lopq/search.py
@@ -1,5 +1,6 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 import heapq
 from collections import defaultdict, namedtuple
 from itertools import count
@@ -12,7 +13,8 @@ def multisequence(x, centroids):
     """
     Implementation of multi-sequence algorithm for traversing a multi-index.
 
-    The algorithm is described in http://download.yandex.ru/company/cvpr2012.pdf.
+    The algorithm is described in:
+    - http://download.yandex.ru/company/cvpr2012.pdf.
 
     :param ndarray x:
         a query vector
@@ -100,8 +102,8 @@ class LOPQSearcherBase(object):
 
     def get_result_quota(self, x, quota=10):
         """
-        Given a query vector and result quota, retrieve as many cells as necessary
-        to fill the quota.
+        Given a query vector and result quota, retrieve as many cells
+        as necessary to fill the quota.
 
         :param ndarray x:
             a query vector
@@ -126,9 +128,10 @@ class LOPQSearcherBase(object):
 
     def compute_distances(self, x, items):
         """
-        Given a query and a list of index items, compute the approximate distance of the query
-        to each item and return a list of tuples that contain the distance and the item.
-        Memoize subquantizer distances per coarse cluster to save work.
+        Given a query and a list of index items, compute the approximate
+        distance of the query to each item and return a list of tuples
+        that contain the distance and the item. Memoize subquantizer
+        distances per coarse cluster to save work.
 
         :param ndarray x:
             a query vector
@@ -171,8 +174,8 @@ class LOPQSearcherBase(object):
 
     def search(self, x, quota=10, limit=None, with_dists=False):
         """
-        Return euclidean distance ranked results, along with the number of cells
-        traversed to fill the quota.
+        Return euclidean distance ranked results, along with the number
+        of cells traversed to fill the quota.
 
         :param ndarray x:
             a query vector
@@ -181,7 +184,8 @@ class LOPQSearcherBase(object):
         :param int limit:
             the number of desired results to return - defaults to quota
         :param bool with_dists:
-            boolean indicating whether result items should be returned with their distance
+            boolean indicating whether result items should be returned
+            with their distance
 
         :returns list results:
             the list of ranked results
@@ -239,9 +243,9 @@ class LOPQSearcherBase(object):
 class LOPQSearcher(LOPQSearcherBase):
     def __init__(self, model):
         """
-        Create an LOPQSearcher instance that encapsulates retrieving and ranking
-        with LOPQ. Requires an LOPQModel instance. This class uses a Python dict
-        to implement the index.
+        Create an LOPQSearcher instance that encapsulates retrieving
+        and ranking with LOPQ. Requires an LOPQModel instance. This class
+        uses a Python dict to implement the index.
 
         :param LOPQModel model:
             the model for indexing and ranking
@@ -283,17 +287,17 @@ class LOPQSearcher(LOPQSearcherBase):
 class LOPQSearcherLMDB(LOPQSearcherBase):
     def __init__(self, model, lmdb_path, id_lambda=int):
         """
-        Create an LOPQSearcher instance that encapsulates retrieving and ranking
-        with LOPQ. Requires an LOPQModel instance. This class uses an lmbd database
-        to implement the index.
+        Create an LOPQSearcher instance that encapsulates retrieving
+        and ranking with LOPQ. Requires an LOPQModel instance.
+        This class uses an lmbd database to implement the index.
 
         :param LOPQModel model:
             the model for indexing and ranking
         :param str lmdb_path:
             path for the lmdb database; if it does not exist it is created
         :param callable id_lambda:
-            a lambda function to reconstruct item ids from their string representation
-            (computed by calling `bytes`) during retrieval
+            a lambda function to reconstruct item ids from their string
+            representation (computed by calling `bytes`) during retrieval
         """
         import lmdb
 

--- a/python/lopq/search.py
+++ b/python/lopq/search.py
@@ -146,10 +146,12 @@ class LOPQSearcherBase(object):
             c0, c1 = coarse
 
             if c0 not in d0:
-                d0[c0] = self.model.get_subquantizer_distances(x, coarse, coarse_split=0)
+                d0[c0] = self.model.get_subquantizer_distances(
+                    x, coarse, coarse_split=0)
 
             if c1 not in d1:
-                d1[c1] = self.model.get_subquantizer_distances(x, coarse, coarse_split=1)
+                d1[c1] = self.model.get_subquantizer_distances(
+                    x, coarse, coarse_split=1)
 
             return d0[c0] + d1[c1]
 
@@ -160,7 +162,8 @@ class LOPQSearcherBase(object):
             coarse, fine = codes
 
             subquantizer_distances = get_subquantizer_distances(x, coarse)
-            dist = sum([subquantizer_distances[i][fc] for i, fc in enumerate(fine)])
+            dist = sum([subquantizer_distances[i][fc]
+                        for i, fc in enumerate(fine)])
 
             results.append((dist, item))
 
@@ -232,6 +235,7 @@ class LOPQSearcherBase(object):
         """
         raise NotImplementedError()
 
+
 class LOPQSearcher(LOPQSearcherBase):
     def __init__(self, model):
         """
@@ -297,7 +301,8 @@ class LOPQSearcherLMDB(LOPQSearcherBase):
         self.lmdb_path = lmdb_path
         self.id_lambda = id_lambda
 
-        self.env = lmdb.open(self.lmdb_path, map_size=1024*2000000*2, writemap=False, map_async=True, max_dbs=1)
+        self.env = lmdb.open(self.lmdb_path, map_size=1024 *
+                             2000000*2, writemap=False, map_async=True, max_dbs=1)
         self.index_db = self.env.open_db("index")
 
     def encode_cell(self, cell):

--- a/python/lopq/utils.py
+++ b/python/lopq/utils.py
@@ -156,8 +156,9 @@ def get_chunk_ranges(N, num_procs):
     per_thread = N / num_procs
     allocation = [per_thread] * num_procs
     allocation[0] += N - num_procs * per_thread
-    data_ranges = [0] + reduce(lambda acc, num: acc +
-                               [num + (acc[-1] if len(acc) else 0)], allocation, [])
+    data_ranges = [0] + reduce(
+        lambda acc, num: acc + [num + (acc[-1] if len(acc) else 0)],
+        allocation, [])
     data_ranges = [(data_ranges[i], data_ranges[i + 1])
                    for i in range(len(data_ranges) - 1)]
     return data_ranges
@@ -165,7 +166,7 @@ def get_chunk_ranges(N, num_procs):
 
 def compute_codes_parallel(data, model, num_procs=4):
     """
-    A helper function that parallelizes the computation of LOPQ codes in 
+    A helper function that parallelizes the computation of LOPQ codes in
     a configurable number of processes.
 
     :param ndarray data:

--- a/python/lopq/utils.py
+++ b/python/lopq/utils.py
@@ -79,7 +79,8 @@ def load_xvecs(filename, base_type='f', max_num=None):
             if j == 0:
                 np.uint32(struct.unpack(format_code, f.read(4)))
             else:
-                A[i, j - 1] = py_type(struct.unpack(format_code, f.read(format_size))[0])
+                A[i, j - 1] = py_type(struct.unpack(format_code,
+                                                    f.read(format_size))[0])
     f.close()
     return np.squeeze(A)
 
@@ -130,7 +131,8 @@ def parmap(f, X, nprocs=multiprocessing.cpu_count()):
     q_in = multiprocessing.Queue(1)
     q_out = multiprocessing.Queue()
 
-    proc = [multiprocessing.Process(target=func_wrap, args=(f, q_in, q_out)) for _ in range(nprocs)]
+    proc = [multiprocessing.Process(target=func_wrap, args=(
+        f, q_in, q_out)) for _ in range(nprocs)]
     for p in proc:
         p.daemon = True
         p.start()
@@ -154,8 +156,10 @@ def get_chunk_ranges(N, num_procs):
     per_thread = N / num_procs
     allocation = [per_thread] * num_procs
     allocation[0] += N - num_procs * per_thread
-    data_ranges = [0] + reduce(lambda acc, num: acc + [num + (acc[-1] if len(acc) else 0)], allocation, [])
-    data_ranges = [(data_ranges[i], data_ranges[i + 1]) for i in range(len(data_ranges) - 1)]
+    data_ranges = [0] + reduce(lambda acc, num: acc +
+                               [num + (acc[-1] if len(acc) else 0)], allocation, [])
+    data_ranges = [(data_ranges[i], data_ranges[i + 1])
+                   for i in range(len(data_ranges) - 1)]
     return data_ranges
 
 

--- a/python/lopq/utils.py
+++ b/python/lopq/utils.py
@@ -1,5 +1,6 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 import numpy as np
 import multiprocessing
 from itertools import chain
@@ -118,7 +119,8 @@ def save_xvecs(data, filename, base_type='f'):
 
 def parmap(f, X, nprocs=multiprocessing.cpu_count()):
     """
-    Parallel map implementation adapted from http://stackoverflow.com/questions/3288595/multiprocessing-using-pool-map-on-a-function-defined-in-a-class
+    Parallel map implementation adapted from
+    http://stackoverflow.com/questions/3288595/multiprocessing-using-pool-map-on-a-function-defined-in-a-class # noqa
     """
 
     def func_wrap(f, q_in, q_out):
@@ -149,9 +151,10 @@ def parmap(f, X, nprocs=multiprocessing.cpu_count()):
 
 def get_chunk_ranges(N, num_procs):
     """
-    A helper that given a number N representing the size of an iterable and the num_procs over which to
-    divide the data return a list of (start_index, end_index) pairs that divide the data as evenly as possible
-    into num_procs buckets.
+    A helper that given a number N representing the size of an iterable
+    and the num_procs over which to divide the data return a list
+    of (start_index, end_index) pairs that divide the data as evenly
+    as possible into num_procs buckets.
     """
     per_thread = N / num_procs
     allocation = [per_thread] * num_procs

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 import os
 import json
 from setuptools import setup
@@ -29,10 +30,14 @@ setup_arguments = {
     'author_email': 'clayton@yahoo-inc.com',
     'url': 'http://github.com/yahoo/lopq',
     'license': 'Apache-2.0',
-    'keywords': ['lopq', 'locally optimized product quantization', 'product quantization', 'compression', 'ann', 'approximate nearest neighbor', 'similarity search'],
+    'keywords': ['lopq', 'locally optimized product quantization',
+                 'product quantization', 'compression', 'ann',
+                 'approximate nearest neighbor', 'similarity search'],
     'packages': ['lopq'],
     'long_description': LONG_DESCRIPTION,
-    'description': 'Python code for training and deploying Locally Optimized Product Quantization (LOPQ) for approximate nearest neighbor search of high dimensional data.',
+    'description': 'Python code for training and deploying Locally Optimized'
+                   'Product Quantization (LOPQ) for approximate nearest'
+                   'neighbor search of high dimensional data.',
     'classifiers': [
             'Development Status :: 5 - Production/Stable',
             'License :: OSI Approved :: Apache Software License',
@@ -53,7 +58,11 @@ setup_arguments = {
     },
     'platforms': 'Windows,Linux,Solaris,Mac OS-X,Unix',
     'include_package_data': True,
-    'install_requires': ['protobuf>=2.6', 'numpy>=1.9', 'scipy>=0.14', 'scikit-learn>=0.18', 'lmdb>=0.87']
+    'install_requires': ['protobuf>=2.6',
+                         'numpy>=1.9',
+                         'scipy>=0.14',
+                         'scikit-learn>=0.18',
+                         'lmdb>=0.87']
 }
 
 
@@ -123,7 +132,7 @@ def add_scripts_to_package():
 
 def get_and_update_package_metadata():
     """
-    Update the package metadata for this package if we are building the package.
+    Update the package metadata when the package is being built.
     :return:metadata - Dictionary of metadata information
     """
     global setup_arguments

--- a/python/setup.py
+++ b/python/setup.py
@@ -13,42 +13,12 @@ BASEPATH = os.path.dirname(os.path.abspath(__file__))
 
 
 # Long description of package
-LONG_DESCRIPTION = """
-# Locally Optimized Product Quantization
+def get_package_description():
+    with open("DESCRIPTION.md", "r") as description:
+        return "".join(description.readlines())
 
-This is Python training and testing code for Locally Optimized Product Quantization (LOPQ) models, as well as Spark scripts to scale training to hundreds of millions of vectors. The resulting model can be used in Python with code provided here or deployed via a Protobuf format to, e.g., search backends for high performance approximate nearest neighbor search.
 
-### Overview
-
-Locally Optimized Product Quantization (LOPQ) [1] is a hierarchical quantization algorithm that produces codes of configurable length for data points. These codes are efficient representations of the original vector and can be used in a variety of ways depending on application, including as hashes that preserve locality, as a compressed vector from which an approximate vector in the data space can be reconstructed, and as a representation from which to compute an approximation of the Euclidean distance between points.
-
-Conceptually, the LOPQ quantization process can be broken into 4 phases. The training process also fits these phases to the data in the same order.
-
-1. The raw data vector is PCA'd to `D` dimensions (possibly the original dimensionality). This allows subsequent quantization to more efficiently represent the variation present in the data.
-2. The PCA'd data is then product quantized [2] by two k-means quantizers. This means that each vector is split into two subvectors each of dimension `D / 2`, and each of the two subspaces is quantized independently with a vocabulary of size `V`. Since the two quantizations occur independently, the dimensions of the vectors are permuted such that the total variance in each of the two subspaces is approximately equal, which allows the two vocabularies to be equally important in terms of capturing the total variance of the data. This results in a pair of cluster ids that we refer to as "coarse codes".
-3. The residuals of the data after coarse quantization are computed. The residuals are then locally projected independently for each coarse cluster. This projection is another application of PCA and dimension permutation on the residuals and it is "local" in the sense that there is a different projection for each cluster in each of the two coarse vocabularies. These local rotations make the next and final step, another application of product quantization, very efficient in capturing the variance of the residuals.
-4. The locally projected data is then product quantized a final time by `M` subquantizers, resulting in `M` "fine codes". Usually the vocabulary for each of these subquantizers will be a power of 2 for effective storage in a search index. With vocabularies of size 256, the fine codes for each indexed vector will require `M` bytes to store in the index.
-
-The final LOPQ code for a vector is a `(coarse codes, fine codes)` pair, e.g. `((3, 2), (14, 164, 83, 49, 185, 29, 196, 250))`.
-
-### Nearest Neighbor Search
-
-A nearest neighbor index can be built from these LOPQ codes by indexing each document into its corresponding coarse code bucket. That is, each pair of coarse codes (which we refer to as a "cell") will index a bucket of the vectors quantizing to that cell.
-
-At query time, an incoming query vector undergoes substantially the same process. First, the query is split into coarse subvectors and the distance to each coarse centroid is computed. These distances can be used to efficiently compute a priority-ordered sequence of cells [3] such that cells later in the sequence are less likely to have near neighbors of the query than earlier cells. The items in cell buckets are retrieved in this order until some desired quota has been met.
-
-After this retrieval phase, the fine codes are used to rank by approximate Euclidean distance. The query is projected into each local space and the distance to each indexed item is estimated as the sum of the squared distances of the query subvectors to the corresponding subquantizer centroid indexed by the fine codes.
-
-NN search with LOPQ is highly scalable and has excellent properties in terms of both index storage requirements and query-time latencies when implemented well.
-
-#### References
-
-For more information and performance benchmarks can be found at http://image.ntua.gr/iva/research/lopq/.
-
-1. Y. Kalantidis, Y. Avrithis. [Locally Optimized Product Quantization for Approximate Nearest Neighbor Search.](http://image.ntua.gr/iva/files/lopq.pdf) CVPR 2014.
-2. H. Jegou, M. Douze, and C. Schmid. [Product quantization for nearest neighbor search.](https://lear.inrialpes.fr/pubs/2011/JDS11/jegou_searching_with_quantization.pdf) PAMI, 33(1), 2011.
-3. A. Babenko and V. Lempitsky. [The inverted multi-index.](http://www.computer.org/csdl/trans/tp/preprint/06915715.pdf) CVPR 2012.
-"""
+LONG_DESCRIPTION = get_package_description()
 
 # Create a dictionary of our arguments, this way this script can be imported
 # without running setup() to allow external scripts to see the setup settings.

--- a/python/test/tests.py
+++ b/python/test/tests.py
@@ -18,7 +18,8 @@ from lopq.eval import compute_all_neighbors, get_cell_histogram, get_recall
 ########################################
 
 
-relpath = lambda x: os.path.abspath(os.path.join(os.path.dirname(__file__), x))
+def relpath(x): return os.path.abspath(
+    os.path.join(os.path.dirname(__file__), x))
 
 
 def load_oxford_data():
@@ -39,7 +40,8 @@ def make_random_model():
 
 
 def test_eigenvalue_allocation():
-    a = pkl.load(open(relpath('./testdata/test_eigenvalue_allocation_input.pkl')))
+    a = pkl.load(
+        open(relpath('./testdata/test_eigenvalue_allocation_input.pkl')))
 
     vals, vecs = np.linalg.eigh(a)
     res = eigenvalue_allocation(4, vals)
@@ -73,8 +75,10 @@ def test_eigenvalue_allocation_normalized_features():
 
 
 def test_accumulate_covariance_estimators():
-    data, centroids = pkl.load(open(relpath('./testdata/test_accumulate_covariance_estimators_input.pkl')))
-    expected = pkl.load(open(relpath('./testdata/test_accumulate_covariance_estimators_output.pkl')))
+    data, centroids = pkl.load(
+        open(relpath('./testdata/test_accumulate_covariance_estimators_input.pkl')))
+    expected = pkl.load(
+        open(relpath('./testdata/test_accumulate_covariance_estimators_output.pkl')))
 
     actual = accumulate_covariance_estimators(data, centroids)
 
@@ -96,8 +100,10 @@ def test_accumulate_covariance_estimators():
 
 def test_compute_rotations_from_accumulators():
 
-    A, mu, count, num_buckets = pkl.load(open(relpath('./testdata/test_compute_rotations_from_accumulators_input.pkl')))
-    expected = pkl.load(open(relpath('./testdata/test_compute_rotations_from_accumulators_output.pkl')))
+    A, mu, count, num_buckets = pkl.load(
+        open(relpath('./testdata/test_compute_rotations_from_accumulators_input.pkl')))
+    expected = pkl.load(
+        open(relpath('./testdata/test_compute_rotations_from_accumulators_output.pkl')))
 
     actual = compute_rotations_from_accumulators(A, mu, count, num_buckets)
 
@@ -113,7 +119,8 @@ def test_reconstruction():
 
     code = ((0, 1), (0, 1, 2, 3))
     r = m.reconstruct(code)
-    expected = [-2.27444688, 6.47126941, 4.5042611, 4.76683476, 0.83671082, 9.36027283, 8.11780532, 6.34846377]
+    expected = [-2.27444688, 6.47126941, 4.5042611, 4.76683476,
+                0.83671082, 9.36027283, 8.11780532, 6.34846377]
 
     assert_true(np.allclose(expected, r))
 
@@ -122,7 +129,8 @@ def test_oxford5k():
 
     random_state = 40
     data = load_oxford_data()
-    train, test = train_test_split(data, test_size=0.2, random_state=random_state)
+    train, test = train_test_split(
+        data, test_size=0.2, random_state=random_state)
 
     # Compute distance-sorted neighbors in training set for each point in test set
     nns = compute_all_neighbors(test, train)
@@ -132,7 +140,8 @@ def test_oxford5k():
     m.fit(train, n_init=1, random_state=random_state)
 
     # Assert correct code computation
-    assert_equal(m.predict(test[0]), ((3, 2), (14, 164, 83, 49, 185, 29, 196, 250)))
+    assert_equal(m.predict(test[0]),
+                 ((3, 2), (14, 164, 83, 49, 185, 29, 196, 250)))
 
     # Assert low number of empty cells
     h = get_cell_histogram(train, m)
@@ -277,7 +286,7 @@ def test_proto_partial():
     import os
 
     filename = './temp_proto_partial.lopq'
-    c = (np.random.rand(8, 8), np.random.rand(8,8))
+    c = (np.random.rand(8, 8), np.random.rand(8, 8))
     m = LOPQModel(parameters=(c, None, None, None))
     m.export_proto(filename)
     m2 = LOPQModel.load_proto(filename)
@@ -289,6 +298,6 @@ def test_proto_partial():
     assert_true(np.allclose(m.Cs[0], m2.Cs[0]))
     assert_true(m.Rs == m2.Rs)
     assert_true(m.mus == m2.mus)
-    assert_true(m.subquantizers ==  m.subquantizers)
+    assert_true(m.subquantizers == m.subquantizers)
 
     os.remove(filename)

--- a/python/test/tests.py
+++ b/python/test/tests.py
@@ -18,8 +18,8 @@ from lopq.eval import compute_all_neighbors, get_cell_histogram, get_recall
 ########################################
 
 
-def relpath(x): return os.path.abspath(
-    os.path.join(os.path.dirname(__file__), x))
+def relpath(x):
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), x))
 
 
 def load_oxford_data():

--- a/python/test/tests.py
+++ b/python/test/tests.py
@@ -1,5 +1,6 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 from nose.tools import assert_true, assert_equal
 
 import pickle as pkl
@@ -8,14 +9,16 @@ import os
 import numpy as np
 from sklearn.model_selection import train_test_split
 
-sys.path.insert(1, os.path.abspath('..'))
-from lopq.model import LOPQModel, eigenvalue_allocation, accumulate_covariance_estimators, compute_rotations_from_accumulators
+sys.path.insert(1, os.path.abspath('..')) # noqa
+from lopq.model import (LOPQModel, eigenvalue_allocation,
+                        accumulate_covariance_estimators,
+                        compute_rotations_from_accumulators)
 from lopq.search import LOPQSearcher, LOPQSearcherLMDB
 from lopq.eval import compute_all_neighbors, get_cell_histogram, get_recall
 
-########################################
+# ============================================================================
 # Helpers
-########################################
+# ============================================================================
 
 
 def relpath(x):
@@ -34,9 +37,9 @@ def make_random_model():
     m.fit(np.random.RandomState(42).rand(200, 8), n_init=1)
     return m
 
-########################################
+# ============================================================================
 # Tests
-########################################
+# ============================================================================
 
 
 def test_eigenvalue_allocation():
@@ -75,10 +78,10 @@ def test_eigenvalue_allocation_normalized_features():
 
 
 def test_accumulate_covariance_estimators():
-    data, centroids = pkl.load(
-        open(relpath('./testdata/test_accumulate_covariance_estimators_input.pkl')))
-    expected = pkl.load(
-        open(relpath('./testdata/test_accumulate_covariance_estimators_output.pkl')))
+    data, centroids = pkl.load(open(relpath(
+        './testdata/test_accumulate_covariance_estimators_input.pkl')))
+    expected = pkl.load(open(relpath(
+        './testdata/test_accumulate_covariance_estimators_output.pkl')))
 
     actual = accumulate_covariance_estimators(data, centroids)
 
@@ -100,10 +103,10 @@ def test_accumulate_covariance_estimators():
 
 def test_compute_rotations_from_accumulators():
 
-    A, mu, count, num_buckets = pkl.load(
-        open(relpath('./testdata/test_compute_rotations_from_accumulators_input.pkl')))
-    expected = pkl.load(
-        open(relpath('./testdata/test_compute_rotations_from_accumulators_output.pkl')))
+    A, mu, count, num_buckets = pkl.load(open(relpath(
+        './testdata/test_compute_rotations_from_accumulators_input.pkl')))
+    expected = pkl.load(open(relpath(
+        './testdata/test_compute_rotations_from_accumulators_output.pkl')))
 
     actual = compute_rotations_from_accumulators(A, mu, count, num_buckets)
 
@@ -132,7 +135,8 @@ def test_oxford5k():
     train, test = train_test_split(
         data, test_size=0.2, random_state=random_state)
 
-    # Compute distance-sorted neighbors in training set for each point in test set
+    # Compute distance-sorted neighbors in training set for each point
+    # in test set
     nns = compute_all_neighbors(test, train)
 
     # Fit model

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -1,10 +1,12 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 import sys
 import os
 
-# Add the lopq module - not needed if they are available in the python environment
-sys.path.append(os.path.abspath('../python'))
+# Add the lopq module - not needed if they are available
+# in the python environment
+sys.path.append(os.path.abspath('../python')) # noqa
 
 import numpy as np
 from sklearn.cross_validation import train_test_split
@@ -26,8 +28,8 @@ def pca(data):
     A simple PCA implementation that demonstrates how eigenvalue allocation
     is used to permute dimensions in order to balance the variance across
     subvectors. There are plenty of PCA implementations elsewhere. What is
-    important is that the eigenvalues can be used to compute a variance-balancing
-    dimension permutation.
+    important is that the eigenvalues can be used to compute
+    a variance-balancing dimension permutation.
     """
 
     # Compute mean
@@ -42,7 +44,8 @@ def pca(data):
     # Compute eigen decomposition
     eigenvalues, P = np.linalg.eigh(A)
 
-    # Compute a permutation of dimensions to balance variance among 2 subvectors
+    # Compute a permutation of dimensions to balance variance among
+    # 2 subvectors
     permuted_inds = eigenvalue_allocation(2, eigenvalues)
 
     # Build the permutation into the rotation matrix. One can alternately keep
@@ -78,23 +81,25 @@ def main():
     # a set of queries for which we will compute the true nearest neighbors.
     train, test = train_test_split(data, test_size=0.2)
 
-    # Compute distance-sorted neighbors in training set for each point in test set.
-    # These will be our groundtruth for recall evaluation.
+    # Compute distance-sorted neighbors in training set for each point
+    # in test set. These will be our groundtruth for recall evaluation.
     nns = compute_all_neighbors(test, train)
 
     # Fit model
     m = LOPQModel(V=16, M=8)
     m.fit(train, n_init=1)
 
-    # Note that we didn't specify a random seed for fitting the model, so different
-    # runs will be different. You may also see a warning that some local projections
-    # can't be estimated because too few points fall in a cluster. This is ok for the
-    # purposes of this demo, but you might want to avoid this by increasing the amount
-    # of training data or decreasing the number of clusters (the V hyperparameter).
+    # Note that we didn't specify a random seed for fitting the model,
+    # so different runs will be different. You may also see a warning that
+    # some local projections can't be estimated because too few points fall
+    # in a cluster. This is ok for the purposes of this demo, but you might
+    # want to avoid this by increasing the amount of training data
+    # or decreasing the number of clusters (the V hyperparameter).
 
-    # With a model in hand, we can test it's recall. We populate a LOPQSearcher
-    # instance with data and get recall stats. By default, we will retrieve 1000
-    # ranked results for each query vector for recall evaluation.
+    # With a model in hand, we can test it's recall. We populate
+    # a LOPQSearcher instance with data and get recall stats. By default,
+    # we will retrieve 1000 ranked results for each query vector for recall
+    # evaluation.
     searcher = LOPQSearcher(m)
     searcher.add_data(train)
     recall, _ = get_recall(searcher, test, nns)
@@ -114,8 +119,8 @@ def main():
     print 'Recall (V=%d, M=%d, subquants=%d): %s' % (
         m2.V, m2.M, m2.subquantizer_clusters, str(recall))
 
-    # The recall is probably higher. We got better recall with a finer quantization
-    # at the expense of more data required for index items.
+    # The recall is probably higher. We got better recall with a finer
+    # quantization at the expense of more data required for index items.
 
     # We can also hold both coarse quantizers and rotations fixed and see what
     # increasing the number of subquantizer clusters does to performance.
@@ -129,10 +134,11 @@ def main():
     print 'Recall (V=%d, M=%d, subquants=%d): %s' % (
         m3.V, m3.M, m3.subquantizer_clusters, str(recall))
 
-    # The recall is probably better than the first but worse than the second. We increased recall
-    # only a little by increasing the number of model parameters (double the subquatizer centroids),
-    # the index storage requirement (another bit for each fine code), and distance computation time
-    # (double the subquantizer centroids).
+    # The recall is probably better than the first but worse than the second.
+    # We increased recall only a little by increasing the number of model
+    # parameters (double the subquatizer centroids), the index storage
+    # requirement (another bit for each fine code), and distance computation
+    # time (double the subquantizer centroids).
 
 
 if __name__ == '__main__':

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -35,7 +35,8 @@ def pca(data):
     mu = data.sum(axis=0) / float(count)
 
     # Compute covariance
-    summed_covar = reduce(lambda acc, x: acc + np.outer(x, x), data, np.zeros((D, D)))
+    summed_covar = reduce(lambda acc, x: acc +
+                          np.outer(x, x), data, np.zeros((D, D)))
     A = summed_covar / (count - 1) - np.outer(mu, mu)
 
     # Compute eigen decomposition
@@ -97,7 +98,8 @@ def main():
     searcher = LOPQSearcher(m)
     searcher.add_data(train)
     recall, _ = get_recall(searcher, test, nns)
-    print 'Recall (V=%d, M=%d, subquants=%d): %s' % (m.V, m.M, m.subquantizer_clusters, str(recall))
+    print 'Recall (V=%d, M=%d, subquants=%d): %s' % (
+        m.V, m.M, m.subquantizer_clusters, str(recall))
 
     # We can experiment with other hyperparameters without discarding all
     # parameters everytime. Here we train a new model that uses the same coarse
@@ -109,20 +111,23 @@ def main():
     searcher = LOPQSearcher(m2)
     searcher.add_data(train)
     recall, _ = get_recall(searcher, test, nns)
-    print 'Recall (V=%d, M=%d, subquants=%d): %s' % (m2.V, m2.M, m2.subquantizer_clusters, str(recall))
+    print 'Recall (V=%d, M=%d, subquants=%d): %s' % (
+        m2.V, m2.M, m2.subquantizer_clusters, str(recall))
 
     # The recall is probably higher. We got better recall with a finer quantization
     # at the expense of more data required for index items.
 
     # We can also hold both coarse quantizers and rotations fixed and see what
     # increasing the number of subquantizer clusters does to performance.
-    m3 = LOPQModel(V=16, M=8, subquantizer_clusters=512, parameters=(m.Cs, m.Rs, m.mus, None))
+    m3 = LOPQModel(V=16, M=8, subquantizer_clusters=512,
+                   parameters=(m.Cs, m.Rs, m.mus, None))
     m3.fit(train, n_init=1)
 
     searcher = LOPQSearcher(m3)
     searcher.add_data(train)
     recall, _ = get_recall(searcher, test, nns)
-    print 'Recall (V=%d, M=%d, subquants=%d): %s' % (m3.V, m3.M, m3.subquantizer_clusters, str(recall))
+    print 'Recall (V=%d, M=%d, subquants=%d): %s' % (
+        m3.V, m3.M, m3.subquantizer_clusters, str(recall))
 
     # The recall is probably better than the first but worse than the second. We increased recall
     # only a little by increasing the number of model parameters (double the subquatizer centroids),

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -35,8 +35,8 @@ def pca(data):
     mu = data.sum(axis=0) / float(count)
 
     # Compute covariance
-    summed_covar = reduce(lambda acc, x: acc +
-                          np.outer(x, x), data, np.zeros((D, D)))
+    summed_covar = reduce(lambda acc, x: acc + np.outer(x, x),
+                          data, np.zeros((D, D)))
     A = summed_covar / (count - 1) - np.outer(mu, mu)
 
     # Compute eigen decomposition

--- a/scripts/query_runtime.py
+++ b/scripts/query_runtime.py
@@ -1,5 +1,6 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 from math import sqrt, ceil
 
 
@@ -9,7 +10,11 @@ def multiseq_flops(V, D):
     compute the number of flops to required to rank each coarse vocabulary
     to the query.
     """
-    # (total coarse vocabulary) * (dims per coarse split) * (flops per squared distance)
+    # (
+    #   (total coarse vocabulary) *
+    #   (dims per coarse split) *
+    #   (flops per squared distance)
+    #  )
     return (2 * V) * (D / 2) * 2
 
 
@@ -28,7 +33,12 @@ def subquantizer_flops(D, M, clusters=256):
     subquantizer vocabulary size, compute the number of flops to compute
     a projected query's LOPQ distance for a single half of the query.
     """
-    # (subquants per half) * (dims per subquant) * (cluster per subquant) * (flops per squared distance)
+    # (
+    #   (subquants per half) *
+    #   (dims per subquant) *
+    #   (cluster per subquant) *
+    #   (flops per squared distance)
+    # )
     return (M / 2) * (D / M) * clusters * 2
 
 
@@ -37,10 +47,11 @@ def total_rank_flops(D, M, N, cells, badness=0.5):
     Given the dimension of the data, the number of subquantizers, the number
     of results to rank, the number of multi-index cells retrieved by the query,
     and a badness measure that interpolates between best case and worst case
-    in terms of reusable (cacheable) subquantizer distance computations, compute
-    the number of flops to rank the N results.
+    in terms of reusable (cacheable) subquantizer distance computations,
+    compute the number of flops to rank the N results.
 
-    The 'badness' will vary query to query and is determined by the data distribution.
+    The 'badness' will vary query to query and is determined by the data
+    distribution.
     """
     # Corresponds to traversing a row or column of the multi-index grid
     worst_case = cells + 1
@@ -51,8 +62,12 @@ def total_rank_flops(D, M, N, cells, badness=0.5):
     # Interpolated number of clusters
     num_clusters = ceil(worst_case * badness + best_case * (1 - badness))
 
-    # (total local projections required) + (total number of sums to compute distance)
-    return num_clusters * (cluster_rotation_flops(D) + subquantizer_flops(D, M)) + N * (M - 1)
+    # (
+    #   (total local projections required) +
+    #   (total number of sums to compute distance)
+    # )
+    return num_clusters * (cluster_rotation_flops(D) + subquantizer_flops(D,
+                           M)) + N * (M - 1)
 
 
 def brute_force_flops(D, N):

--- a/spark/compute_codes.py
+++ b/spark/compute_codes.py
@@ -17,14 +17,17 @@ def default_data_loading(sc, data_path, sampling_ratio, seed):
     The data is returned as an RDD of (id, numpy array) tuples.
     """
     # Compute the number of cores in our cluster - used below to heuristically set the number of partitions
-    total_cores = int(sc._conf.get('spark.executor.instances')) * int(sc._conf.get('spark.executor.cores'))
+    total_cores = int(sc._conf.get('spark.executor.instances')
+                      ) * int(sc._conf.get('spark.executor.cores'))
 
     # Load and sample down the dataset
-    d = sc.textFile(data_path, total_cores * 3).sample(False, sampling_ratio, seed)
+    d = sc.textFile(data_path, total_cores *
+                    3).sample(False, sampling_ratio, seed)
 
     # The data is (id, vector) tab-delimited pairs where each vector is
     # a base64-encoded pickled numpy array
-    d = d.map(lambda x: x.split('\t')).map(lambda x: (x[0], pkl.loads(base64.decodestring(x[1]))))
+    d = d.map(lambda x: x.split('\t')).map(
+        lambda x: (x[0], pkl.loads(base64.decodestring(x[1]))))
 
     return d
 
@@ -45,24 +48,33 @@ def main(sc, args, data_load_fn=default_data_loading):
     m = sc.broadcast(model)
 
     # Compute codes and convert to string
-    codes = d.map(lambda x: (x[0], m.value.predict(x[1]))).map(lambda x: '%s\t%s' % (x[0], json.dumps(x[1])))
+    codes = d.map(lambda x: (x[0], m.value.predict(x[1]))).map(
+        lambda x: '%s\t%s' % (x[0], json.dumps(x[1])))
 
     codes.saveAsTextFile(args.output)
+
 
 if __name__ == "__main__":
     from argparse import ArgumentParser
     parser = ArgumentParser()
 
     # Data handling parameters
-    parser.add_argument('--data', dest='data', type=str, default=None, required=True, help='hdfs path to input data')
-    parser.add_argument('--data_udf', dest='data_udf', type=str, default=None, help='module name from which to load a data loading UDF')
-    parser.add_argument('--seed', dest='seed', type=int, default=None, help='optional random seed for sampling')
-    parser.add_argument('--sampling_ratio', dest='sampling_ratio', type=float, default=1.0, help='proportion of data to sample for model application')
-    parser.add_argument('--output', dest='output', type=str, default=None, required=True, help='hdfs path to output data')
+    parser.add_argument('--data', dest='data', type=str, default=None,
+                        required=True, help='hdfs path to input data')
+    parser.add_argument('--data_udf', dest='data_udf', type=str, default=None,
+                        help='module name from which to load a data loading UDF')
+    parser.add_argument('--seed', dest='seed', type=int,
+                        default=None, help='optional random seed for sampling')
+    parser.add_argument('--sampling_ratio', dest='sampling_ratio', type=float,
+                        default=1.0, help='proportion of data to sample for model application')
+    parser.add_argument('--output', dest='output', type=str,
+                        default=None, required=True, help='hdfs path to output data')
 
     existing_model_group = parser.add_mutually_exclusive_group(required=True)
-    existing_model_group.add_argument('--model_pkl', dest='model_pkl', type=str, default=None, help='a pickled LOPQModel to evaluate on the data')
-    existing_model_group.add_argument('--model_proto', dest='model_proto', type=str, default=None, help='a protobuf LOPQModel to evaluate on the data')
+    existing_model_group.add_argument('--model_pkl', dest='model_pkl', type=str,
+                                      default=None, help='a pickled LOPQModel to evaluate on the data')
+    existing_model_group.add_argument('--model_proto', dest='model_proto', type=str,
+                                      default=None, help='a protobuf LOPQModel to evaluate on the data')
 
     args = parser.parse_args()
 

--- a/spark/compute_codes.py
+++ b/spark/compute_codes.py
@@ -21,8 +21,8 @@ def default_data_loading(sc, data_path, sampling_ratio, seed):
                       ) * int(sc._conf.get('spark.executor.cores'))
 
     # Load and sample down the dataset
-    d = sc.textFile(data_path, total_cores *
-                    3).sample(False, sampling_ratio, seed)
+    d = (sc.textFile(data_path, total_cores * 3)
+         .sample(False, sampling_ratio, seed))
 
     # The data is (id, vector) tab-delimited pairs where each vector is
     # a base64-encoded pickled numpy array

--- a/spark/compute_codes.py
+++ b/spark/compute_codes.py
@@ -1,5 +1,6 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 from pyspark.context import SparkContext
 
 import cPickle as pkl
@@ -10,13 +11,13 @@ from lopq.model import LOPQModel
 
 
 def default_data_loading(sc, data_path, sampling_ratio, seed):
+    """ This function loads data from a text file, sampling it by the provided
+    ratio and random seed, and interprets each line as a tab-separated
+    (id, data) pair where 'data' is assumed to be a base64-encoded pickled
+    numpy array. The data is returned as an RDD of (id, numpy array) tuples.
     """
-    This function loads data from a text file, sampling it by the provided
-    ratio and random seed, and interprets each line as a tab-separated (id, data) pair
-    where 'data' is assumed to be a base64-encoded pickled numpy array.
-    The data is returned as an RDD of (id, numpy array) tuples.
-    """
-    # Compute the number of cores in our cluster - used below to heuristically set the number of partitions
+    # Compute the number of cores in our cluster.
+    # used below to heuristically set the number of partitions
     total_cores = int(sc._conf.get('spark.executor.instances')
                       ) * int(sc._conf.get('spark.executor.cores'))
 
@@ -59,22 +60,29 @@ if __name__ == "__main__":
     parser = ArgumentParser()
 
     # Data handling parameters
-    parser.add_argument('--data', dest='data', type=str, default=None,
-                        required=True, help='hdfs path to input data')
-    parser.add_argument('--data_udf', dest='data_udf', type=str, default=None,
-                        help='module name from which to load a data loading UDF')
-    parser.add_argument('--seed', dest='seed', type=int,
-                        default=None, help='optional random seed for sampling')
-    parser.add_argument('--sampling_ratio', dest='sampling_ratio', type=float,
-                        default=1.0, help='proportion of data to sample for model application')
-    parser.add_argument('--output', dest='output', type=str,
-                        default=None, required=True, help='hdfs path to output data')
+    parser.add_argument(
+        '--data', dest='data', type=str, default=None,
+        required=True, help='hdfs path to input data')
+    parser.add_argument(
+        '--data_udf', dest='data_udf', type=str, default=None,
+        help='module name from which to load a data loading UDF')
+    parser.add_argument(
+        '--seed', dest='seed', type=int,
+        default=None, help='optional random seed for sampling')
+    parser.add_argument(
+        '--sampling_ratio', dest='sampling_ratio', type=float,
+        default=1.0, help='proportion of data to sample for model application')
+    parser.add_argument(
+        '--output', dest='output', type=str,
+        default=None, required=True, help='hdfs path to output data')
 
     existing_model_group = parser.add_mutually_exclusive_group(required=True)
-    existing_model_group.add_argument('--model_pkl', dest='model_pkl', type=str,
-                                      default=None, help='a pickled LOPQModel to evaluate on the data')
-    existing_model_group.add_argument('--model_proto', dest='model_proto', type=str,
-                                      default=None, help='a protobuf LOPQModel to evaluate on the data')
+    existing_model_group.add_argument(
+        '--model_pkl', dest='model_pkl', type=str,
+        default=None, help='a pickled LOPQModel to evaluate on the data')
+    existing_model_group.add_argument(
+        '--model_proto', dest='model_proto', type=str,
+        default=None, help='a protobuf LOPQModel to evaluate on the data')
 
     args = parser.parse_args()
 

--- a/spark/example_udf.py
+++ b/spark/example_udf.py
@@ -1,16 +1,18 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 import cPickle as pkl
 import base64
 
 
 def udf(sc, data_path, sampling_ratio, seed):
     """
-    This is an example UDF function to load training data. It loads data from a text file
-    with base64-encoded pickled numpy arrays on each line.
+    This is an example UDF function to load training data. It loads data from
+    a text file with base64-encoded pickled numpy arrays on each line.
     """
 
-    # Compute the number of cores in our cluster - used below to heuristically set the number of partitions
+    # Compute the number of cores in our cluster.
+    # used below to heuristically set the number of partitions
     total_cores = int(sc._conf.get('spark.executor.instances')
                       ) * int(sc._conf.get('spark.executor.cores'))
 

--- a/spark/example_udf.py
+++ b/spark/example_udf.py
@@ -15,10 +15,10 @@ def udf(sc, data_path, sampling_ratio, seed):
                       ) * int(sc._conf.get('spark.executor.cores'))
 
     # Load and sample down the dataset
-    d = sc.textFile(data_path, total_cores *
-                    3).sample(False, sampling_ratio, seed)
+    d = (sc.textFile(data_path, total_cores * 3)
+         .sample(False, sampling_ratio, seed))
 
-    def deserialize_vec(s): return pkl.loads(base64.decodestring(s))
-    vecs = d.map(deserialize_vec)
+    def deserialize_vec(s):
+        return pkl.loads(base64.decodestring(s))
 
-    return vecs
+    return d.map(deserialize_vec)

--- a/spark/example_udf.py
+++ b/spark/example_udf.py
@@ -11,12 +11,14 @@ def udf(sc, data_path, sampling_ratio, seed):
     """
 
     # Compute the number of cores in our cluster - used below to heuristically set the number of partitions
-    total_cores = int(sc._conf.get('spark.executor.instances')) * int(sc._conf.get('spark.executor.cores'))
+    total_cores = int(sc._conf.get('spark.executor.instances')
+                      ) * int(sc._conf.get('spark.executor.cores'))
 
     # Load and sample down the dataset
-    d = sc.textFile(data_path, total_cores * 3).sample(False, sampling_ratio, seed)
+    d = sc.textFile(data_path, total_cores *
+                    3).sample(False, sampling_ratio, seed)
 
-    deserialize_vec = lambda s: pkl.loads(base64.decodestring(s))
+    def deserialize_vec(s): return pkl.loads(base64.decodestring(s))
     vecs = d.map(deserialize_vec)
 
     return vecs

--- a/spark/pca_preparation.py
+++ b/spark/pca_preparation.py
@@ -23,14 +23,14 @@ def main(args):
 
     # Reduce dimension - eigenvalues assumed in ascending order
     E = E[-args.D:]
-    P = P[:,-args.D:]
+    P = P[:, -args.D:]
 
     # Balance variance across halves
     permuted_inds = eigenvalue_allocation(2, E)
     P = P[:, permuted_inds]
 
     # Save new params
-    pkl.dump({ 'P': P, 'mu': mu }, open(args.output, 'w'))
+    pkl.dump({'P': P, 'mu': mu}, open(args.output, 'w'))
 
 
 def apply_PCA(x, mu, P):
@@ -44,9 +44,12 @@ if __name__ == '__main__':
     from argparse import ArgumentParser
     parser = ArgumentParser()
 
-    parser.add_argument('--pca_params', dest='pca_params', type=str, required=True, help='path to pickle file of PCA parameters')
-    parser.add_argument('--D', dest='D', type=int, default=128, help='desired final feature dimension')
-    parser.add_argument('--output', dest='output', type=str, required=True, help='path to pickle file of new PCA parameters')
+    parser.add_argument('--pca_params', dest='pca_params', type=str,
+                        required=True, help='path to pickle file of PCA parameters')
+    parser.add_argument('--D', dest='D', type=int, default=128,
+                        help='desired final feature dimension')
+    parser.add_argument('--output', dest='output', type=str,
+                        required=True, help='path to pickle file of new PCA parameters')
     args = parser.parse_args()
 
     main(args)

--- a/spark/pca_preparation.py
+++ b/spark/pca_preparation.py
@@ -1,12 +1,15 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 """
-This script illustrates how to prepare PCA parameters before using them in the LOPQ pipeline.
+This script illustrates how to prepare PCA parameters before using them
+in the LOPQ pipeline.
 
-The `pca_params` argument is the path to a pickle file containing PCA parameters like that
-produced as a result of `train_pca.py`, and the `D` argument is the desired dimension of the
-final feature. This script truncates then permutes the dimensions of the PCA matrix to balance
-the variance across the the two halves of the final vector.
+The `pca_params` argument is the path to a pickle file containing PCA
+parameters like that produced as a result of `train_pca.py`, and the `D`
+argument is the desired dimension of the final feature. This script truncates
+then permutes the dimensions of the PCA matrix to balance the variance across
+the the two halves of the final vector.
 """
 import cPickle as pkl
 import numpy as np
@@ -43,12 +46,15 @@ if __name__ == '__main__':
     from argparse import ArgumentParser
     parser = ArgumentParser()
 
-    parser.add_argument('--pca_params', dest='pca_params', type=str,
-                        required=True, help='path to pickle file of PCA parameters')
-    parser.add_argument('--D', dest='D', type=int, default=128,
-                        help='desired final feature dimension')
-    parser.add_argument('--output', dest='output', type=str,
-                        required=True, help='path to pickle file of new PCA parameters')
+    parser.add_argument(
+        '--pca_params', dest='pca_params', type=str,
+        required=True, help='path to pickle file of PCA parameters')
+    parser.add_argument(
+        '--D', dest='D', type=int, default=128,
+        help='desired final feature dimension')
+    parser.add_argument(
+        '--output', dest='output', type=str,
+        required=True, help='path to pickle file of new PCA parameters')
     args = parser.parse_args()
 
     main(args)

--- a/spark/pca_preparation.py
+++ b/spark/pca_preparation.py
@@ -3,13 +3,12 @@
 """
 This script illustrates how to prepare PCA parameters before using them in the LOPQ pipeline.
 
-The `pca_params` argument is the path to a pickle file containing PCA parameters like that 
+The `pca_params` argument is the path to a pickle file containing PCA parameters like that
 produced as a result of `train_pca.py`, and the `D` argument is the desired dimension of the
 final feature. This script truncates then permutes the dimensions of the PCA matrix to balance
 the variance across the the two halves of the final vector.
 """
 import cPickle as pkl
-import base64
 import numpy as np
 from lopq.model import eigenvalue_allocation
 

--- a/spark/train_model.py
+++ b/spark/train_model.py
@@ -32,13 +32,13 @@ def default_data_loading(sc, data_path, sampling_ratio, seed):
                       ) * int(sc._conf.get('spark.executor.cores'))
 
     # Load and sample down the dataset
-    d = sc.textFile(data_path, total_cores *
-                    3).sample(False, sampling_ratio, seed)
+    d = (sc.textFile(data_path, total_cores * 3)
+         .sample(False, sampling_ratio, seed))
 
     # The data is (id, vector) tab-delimited pairs where each vector is
     # a base64-encoded pickled numpy array
-    def deserialize_vec(s): return pkl.loads(
-        base64.decodestring(s.split('\t')[1]))
+    def deserialize_vec(s):
+        return pkl.loads(base64.decodestring(s.split('\t')[1]))
     vecs = d.map(deserialize_vec)
 
     return vecs
@@ -389,8 +389,12 @@ if __name__ == "__main__":
     args = validate_arguments(args, model)
 
     # Build descriptive app name
-    def get_step_name(x): return {
-        STEP_COARSE: 'coarse', STEP_ROTATION: 'rotations', STEP_SUBQUANT: 'subquantizers'}.get(x, None)
+    def get_step_name(x):
+        mapping = {STEP_COARSE: 'coarse',
+                   STEP_ROTATION: 'rotations',
+                   STEP_SUBQUANT: 'subquantizers'}
+        return mapping.get(x, None)
+
     steps_str = ', '.join(filter(lambda x: x is not None,
                                  map(get_step_name, sorted(args.steps))))
     APP_NAME = 'LOPQ{V=%d,M=%d}; training %s' % (args.V, args.M, steps_str)

--- a/spark/train_pca.py
+++ b/spark/train_pca.py
@@ -13,23 +13,26 @@ from operator import add
 
 def default_data_loading(sc, data_path, sampling_ratio, seed):
     """
-    This function loads training data from a text file, sampling it by the provided
-    ratio and random seed, and interprets each line as a tab-separated (id, data) pair
-    where 'data' is assumed to be a base64-encoded pickled numpy array. The ids are discarded.
+    This function loads training data from a text file,
+    sampling it by the provided ratio and random seed, and interprets
+    each line as a tab-separated (id, data) pair where 'data' is assumed
+    to be a base64-encoded pickled numpy array. The ids are discarded.
     The data is returned as an RDD of numpy arrays.
     """
-    # Compute the number of cores in our cluster - used below to heuristically set the number of partitions
+    # Compute the number of cores in our cluster - used below
+    # to heuristically set the number of partitions
     total_cores = int(sc._conf.get('spark.executor.instances')
                       ) * int(sc._conf.get('spark.executor.cores'))
 
     # Load and sample down the dataset
-    d = sc.textFile(data_path, total_cores *
-                    3).sample(False, sampling_ratio, seed)
+    d = (sc.textFile(data_path, total_cores * 3)
+         .sample(False, sampling_ratio, seed)
+         )
 
     # The data is (id, vector) tab-delimited pairs where each vector is
     # a base64-encoded pickled numpy array
-    def deserialize_vec(s): return pkl.loads(
-        base64.decodestring(s.split('\t')[1]))
+    def deserialize_vec(s):
+        return pkl.loads(base64.decodestring(s.split('\t')[1]))
     vecs = d.map(deserialize_vec)
 
     return vecs

--- a/spark/train_pca.py
+++ b/spark/train_pca.py
@@ -1,5 +1,6 @@
 # Copyright 2015, Yahoo Inc.
-# Licensed under the terms of the Apache License, Version 2.0. See the LICENSE file associated with the project for terms.
+# Licensed under the terms of the Apache License, Version 2.0.
+# See the LICENSE file associated with the project for terms.
 from pyspark.context import SparkContext
 
 import numpy as np
@@ -80,8 +81,8 @@ def main(sc, args, data_load_fn=default_data_loading):
 
 def save_hdfs_pickle(m, pkl_path):
     """
-    Given a python object and a path on hdfs, save the object as a pickle file locally and copy the file
-    to the hdfs path.
+    Given a python object and a path on hdfs, save the object as a pickle
+    file locally and copy the file to the hdfs path.
     """
     print 'Saving pickle to temp file...'
     f = NamedTemporaryFile(delete=False)
@@ -102,16 +103,21 @@ if __name__ == '__main__':
     parser = ArgumentParser()
 
     # Data handling parameters
-    parser.add_argument('--data', dest='data', type=str,
-                        required=True, help='hdfs path to input data')
-    parser.add_argument('--data_udf', dest='data_udf', type=str, default=None,
-                        help='module name from which to load a data loading UDF')
-    parser.add_argument('--seed', dest='seed', type=int,
-                        default=None, help='optional random seed')
-    parser.add_argument('--sampling_ratio', dest='sampling_ratio', type=float,
-                        default=1.0, help='proportion of data to sample for training')
-    parser.add_argument('--agg_depth', dest='agg_depth', type=int, default=4,
-                        help='depth of tree aggregation to compute covariance estimator')
+    parser.add_argument(
+        '--data', dest='data', type=str,
+        required=True, help='hdfs path to input data')
+    parser.add_argument(
+        '--data_udf', dest='data_udf', type=str, default=None,
+        help='module name from which to load a data loading UDF')
+    parser.add_argument(
+        '--seed', dest='seed', type=int,
+        default=None, help='optional random seed')
+    parser.add_argument(
+        '--sampling_ratio', dest='sampling_ratio', type=float,
+        default=1.0, help='proportion of data to sample for training')
+    parser.add_argument(
+        '--agg_depth', dest='agg_depth', type=int, default=4,
+        help='depth of tree aggregation to compute covariance estimator')
 
     parser.add_argument('--output', dest='output', type=str, default=None,
                         help='hdfs path to output pickle file of parameters')


### PR DESCRIPTION
The purpose of this PR is to improve the code quality by reducing the number of alerts thrown by [flake8](http://flake8.pycqa.org/en/latest/):

```
$ flake8 . | wc -l 
     334
```
After the PR:

```
$ flake8 . | wc -l 
     235
```

The fourth commit reduces further the number of flake8 issues:

```
$ flake8 --exclude ./python/lopq/lopq_model_pb2.py . | wc -l 
     155
```

With commit 5-> 7 the number of issues is further reduced:

```
$ flake8 --exclude ./python/lopq/lopq_model_pb2.py . | wc -l 
     112
```

Down to 57 with the commit 8:
```
$ flake8 --exclude=./python/lopq/lopq_model_pb2.py .  | wc -l 
      57
```

The commits 9 and 10 finish fixing all identified flake8 issues:

```
$ flake8 --exclude=./python/lopq/lopq_model_pb2.py . | wc -l 
       0
```

PS: `lopq_model_pb2.py` is skipped because it's autogenerated by protobuf